### PR TITLE
Fix build failures with `-x check` flag

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x check -x test
+        run: ./gradlew build -x test
       - name: Create lib directory if not exists
         run: mkdir -p ballerina/lib
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
-          ./gradlew build -x check -x test
+          ./gradlew build -x test
       - name: Create lib directory if not exists
         run: mkdir -p ballerina/lib
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x check -x test
+        run: ./gradlew build -x test
       - name: Create lib directory if not exists
         run: mkdir -p ballerina/lib
       - name: Run Trivy vulnerability scanner

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "h2.driver"
-version = "1.1.0"
+version = "1.0.0"
 authors = ["Ballerina"]
 keywords = ["H2"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-h2.driver"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.7.0"
 [[package]]
 org = "ballerinax"
 name = "h2.driver"
-version = "1.1.0"
+version = "1.0.0"
 modules = [
 	{org = "ballerinax", packageName = "h2.driver", moduleName = "h2.driver"}
 ]

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -9,6 +9,8 @@ This Package bundles the latest H2 driver so that `java.jdbc` connector can be u
 |Ballerina Language | **2201.7.0** |
 |H2 Driver* |  **2.2.220**  |
 
+> * H2 is dual licensed and available under the MPL 2.0 (Mozilla Public License Version 2.0) or under the EPL 1.0 (Eclipse Public License).
+
 ## Usage
 
 To add the H2 driver dependency the project simply import the module as below,

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -9,6 +9,8 @@ This Package bundles the latest H2 driver so that `java.jdbc` connector can be u
 |Ballerina Language | **2201.7.0** |
 |H2 Driver* |  **2.2.220**  |
 
+> * H2 is dual licensed and available under the MPL 2.0 (Mozilla Public License Version 2.0) or under the EPL 1.0 (Eclipse Public License).
+
 ## Usage
 
 To add the H2 driver dependency the project simply import the module as below,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.stdlib
-version=1.1.0
+version=1.0.0-SNAPSHOT
 
 githubSpotbugsVersion=4.0.5
 githubJohnrengelmanShadowVersion=5.2.0


### PR DESCRIPTION
## Purpose

> $Subject

When we run `./gradlew clean build -x check` it fails with the following error since there is no native Java module that imports this task. When we add the native module with GraalVM check, we can skip this.

## Examples

N/A

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the specification~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Checked native-image compatibility~
